### PR TITLE
Remove SMS option and adopt red-white theme

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -131,12 +131,12 @@ export default function KeepGoingApp() {
         <div className="text-center mb-8 relative">
           <h1 className="text-7xl md:text-8xl font-black tracking-tighter mb-2 text-red-500 font-impact">KEEP</h1>
           <h1 className="text-7xl md:text-6xl font-black tracking-tighter mb-4 font-impact">GOING</h1>
-          <p className="text-lg md:text-xl font-bold text-gray-300 max-w-md mx-auto leading-tight">
+          <p className="text-lg md:text-xl font-bold text-white max-w-md mx-auto leading-tight">
           Motivation fades. These reminders won’t.          </p>
           <Button
             onClick={handleSignOut}
             variant="ghost"
-            className="absolute top-0 right-0 text-gray-500 hover:text-red-400"
+            className="absolute top-0 right-0 text-white hover:text-red-400"
             >
                 <LogOut size={16}/>
             </Button>
@@ -151,7 +151,7 @@ export default function KeepGoingApp() {
 
         {/* Brutal Mode Toggle */}
         {/*
-        <div className="mb-8 p-6 bg-gray-900 border-2 border-gray-700 rounded-lg">
+        <div className="mb-8 p-6 bg-black border-2 border-red-600 rounded-lg">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center space-x-3">
               <Skull className="h-6 w-6 text-red-500" />
@@ -160,10 +160,10 @@ export default function KeepGoingApp() {
           </div>
           <p className="text-red-400 font-bold text-sm mb-2">Brutal Mode is coming soon. Join the waitlist to be the first to try it.</p>
           {waitlistCount !== null && (
-            <p className="text-gray-400 font-bold mb-2">{waitlistCount} people are already on the waitlist.</p>
+            <p className="text-white font-bold mb-2">{waitlistCount} people are already on the waitlist.</p>
           )}
           {waitlistSubmitted ? (
-            <p className="text-green-400 font-bold">Thank you for joining the waitlist!</p>
+            <p className="text-red-400 font-bold">Thank you for joining the waitlist!</p>
           ) : (
             <form
               onSubmit={async (e) => {
@@ -186,14 +186,14 @@ export default function KeepGoingApp() {
                 placeholder="Email address"
                 value={waitlistEmail}
                 onChange={e => setWaitlistEmail(e.target.value)}
-                className="rounded px-3 py-2 bg-gray-800 border border-gray-700 text-white"
+                className="rounded px-3 py-2 bg-black border border-white text-white"
               />
               <input
                 type="tel"
                 placeholder="Phone number (optional)"
                 value={waitlistPhone}
                 onChange={e => setWaitlistPhone(e.target.value)}
-                className="rounded px-3 py-2 bg-gray-800 border border-gray-700 text-white"
+                className="rounded px-3 py-2 bg-black border border-white text-white"
               />
               <button
                 type="submit"
@@ -209,12 +209,12 @@ export default function KeepGoingApp() {
         {/* Regular Messages Section */}
         <div className="mb-8">
           <h2 className="text-2xl font-black mb-4 text-red-400 font-impact">MOTIVATION MESSAGE</h2>
-          <p className="text-gray-400 mb-4 font-bold">Write what you need to hear when you're ready to quit.</p>
+          <p className="text-white mb-4 font-bold">Write what you need to hear when you're ready to quit.</p>
           <Textarea
             value={message}
             onChange={(e) => setMessage(e.target.value)}
             placeholder="If you quit now, you're just proving yourself right, that you never had it in you."
-            className="bg-gray-900 border-2 border-gray-700 text-white placeholder-gray-500 min-h-[100px] text-base font-bold resize-none focus:border-red-500 focus:ring-red-500"
+            className="bg-black border-2 border-red-600 text-white placeholder-white min-h-[100px] text-base font-bold resize-none focus:border-red-500 focus:ring-red-500"
           />
         </div>
 
@@ -224,7 +224,7 @@ export default function KeepGoingApp() {
         {/* Interval Selection */}
         <div className="mb-10">
           <h2 className="text-2xl font-black mb-4 text-red-400 font-impact">REMINDER FREQUENCY</h2>
-          <p className="text-gray-400 mb-6 font-bold">
+          <p className="text-white mb-6 font-bold">
             How often do you need the push? Current: {" "}
             <span className="text-white font-black">{getIntervalText(interval)}</span>
           </p>
@@ -247,7 +247,7 @@ export default function KeepGoingApp() {
                   className={`p-3 rounded font-black transition-all ${
                     interval === mins
                       ? "bg-red-600 text-white shadow-lg"
-                      : "bg-gray-800 text-gray-300 hover:bg-gray-700 hover:text-white"
+                      : "bg-black text-white hover:bg-red-700"
                   }`}
                 >
                   {getIntervalText(mins)}
@@ -263,7 +263,7 @@ export default function KeepGoingApp() {
             <Button
               onClick={handleStart}
               disabled={!message.trim() || !phoneNumber.trim()}
-              className="flex-1 bg-red-600 hover:bg-red-700 text-white font-black text-xl h-16 disabled:bg-gray-800 disabled:text-gray-500 shadow-lg transition-all"
+              className="flex-1 bg-red-600 hover:bg-red-700 text-white font-black text-xl h-16 disabled:bg-white disabled:text-red-500 shadow-lg transition-all"
             >
               <Play className="h-6 w-6 mr-3" />
               START REMINDERS
@@ -271,7 +271,7 @@ export default function KeepGoingApp() {
           ) : (
             <Button
               onClick={handleStop}
-              className="flex-1 bg-gray-800 hover:bg-gray-700 text-white font-black text-xl h-16 border-2 border-gray-600 shadow-lg transition-all"
+              className="flex-1 bg-black hover:bg-red-700 text-white font-black text-xl h-16 border-2 border-red-600 shadow-lg transition-all"
             >
               <Square className="h-6 w-6 mr-3" />
               STOP REMINDERS
@@ -282,16 +282,16 @@ export default function KeepGoingApp() {
         {/* Hidden Done Link */}
         {isActive && (
           <div className="text-center mb-8">
-            <a href="/done" onClick={handleDone} className="text-gray-600 hover:text-gray-400 font-bold text-sm underline transition-colors">
+            <a href="/done" onClick={handleDone} className="text-white hover:text-red-400 font-bold text-sm underline transition-colors">
               Mark as done (from SMS)
             </a>
           </div>
         )}
 
         {/* Footer */}
-        <div className="text-center border-t border-gray-800 pt-8">
-          <p className="text-gray-600 font-bold">When the world gets quiet, your excuses get loud.</p>
-          <p className="text-gray-600 font-bold mt-2">This is the voice that doesn't let you lie to yourself.</p>
+        <div className="text-center border-t border-red-600 pt-8">
+          <p className="text-white font-bold">When the world gets quiet, your excuses get loud.</p>
+          <p className="text-white font-bold mt-2">This is the voice that doesn't let you lie to yourself.</p>
           {/* Removed brutal mode footer message */}
         </div>
       </div>

--- a/app/done/page.tsx
+++ b/app/done/page.tsx
@@ -22,19 +22,19 @@ export default function DonePage() {
       <div className="max-w-md mx-auto text-center">
         {!confirmed ? (
           <div className="animate-pulse">
-            <CheckCircle className="h-24 w-24 text-green-500 mx-auto mb-6" />
-            <h1 className="text-4xl font-black mb-4 text-green-400 font-impact">CHECKING IN...</h1>
-            <p className="text-gray-400 font-bold">Confirming your progress...</p>
+            <CheckCircle className="h-24 w-24 text-red-500 mx-auto mb-6" />
+            <h1 className="text-4xl font-black mb-4 text-red-400 font-impact">CHECKING IN...</h1>
+            <p className="text-white font-bold">Confirming your progress...</p>
           </div>
         ) : (
           <div>
-            <CheckCircle className="h-24 w-24 text-green-500 mx-auto mb-6" />
-            <h1 className="text-5xl font-black mb-4 text-green-400 font-impact">DONE!</h1>
-            <p className="text-xl font-bold text-gray-300 mb-8">You showed up. That's what matters.</p>
-            <p className="text-gray-400 font-bold mb-8">Keep this momentum going. The grind never stops.</p>
+            <CheckCircle className="h-24 w-24 text-red-500 mx-auto mb-6" />
+            <h1 className="text-5xl font-black mb-4 text-red-400 font-impact">DONE!</h1>
+            <p className="text-xl font-bold text-white mb-8">You showed up. That's what matters.</p>
+            <p className="text-white font-bold mb-8">Keep this momentum going. The grind never stops.</p>
 
             <Link href="/">
-              <Button className="bg-green-600 hover:bg-green-700 text-white font-black text-lg px-8 py-4">
+              <Button className="bg-red-600 hover:bg-red-700 text-white font-black text-lg px-8 py-4">
                 <ArrowLeft className="h-5 w-5 mr-2" />
                 BACK TO REMINDERS
               </Button>

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,23 +5,23 @@
 :root {
   --background: 0 0% 0%;
   --foreground: 0 0% 100%;
-  --card: 0 0% 5%;
+  --card: 0 0% 0%;
   --card-foreground: 0 0% 100%;
-  --popover: 0 0% 5%;
+  --popover: 0 0% 0%;
   --popover-foreground: 0 0% 100%;
-  --primary: 0 84% 60%;
+  --primary: 0 100% 50%;
   --primary-foreground: 0 0% 100%;
-  --secondary: 0 0% 10%;
+  --secondary: 0 0% 0%;
   --secondary-foreground: 0 0% 100%;
-  --muted: 0 0% 10%;
-  --muted-foreground: 0 0% 60%;
-  --accent: 0 0% 10%;
+  --muted: 0 0% 0%;
+  --muted-foreground: 0 0% 100%;
+  --accent: 0 0% 0%;
   --accent-foreground: 0 0% 100%;
-  --destructive: 0 84% 60%;
+  --destructive: 0 100% 50%;
   --destructive-foreground: 0 0% 100%;
-  --border: 0 0% 20%;
-  --input: 0 0% 20%;
-  --ring: 0 84% 60%;
+  --border: 0 100% 50%;
+  --input: 0 0% 100%;
+  --ring: 0 100% 50%;
   --radius: 0.5rem;
 }
 
@@ -46,7 +46,7 @@ body {
 
 /* Custom slider styling */
 [data-radix-slider-track] {
-  background-color: rgb(55, 65, 81);
+  background-color: rgb(255, 255, 255);
   height: 10px;
   border-radius: 5px;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ import { isValidPhoneNumber } from "libphonenumber-js"
 
 export default function SignInPage() {
   const [phoneNumber, setPhoneNumber] = useState("")
-  const [channel, setChannel] = useState<"whatsapp" | "sms">("whatsapp")
+  const [channel, setChannel] = useState<"whatsapp">("whatsapp")
   const [isValid, setIsValid] = useState(false)
   const [waitlistEmail, setWaitlistEmail] = useState("")
   const [waitlistPhone, setWaitlistPhone] = useState("")
@@ -87,7 +87,7 @@ export default function SignInPage() {
         <h1 className="text-7xl md:text-9xl font-black tracking-tighter mb-6 font-impact">GOING</h1>
 
         {/* Description */}
-        <p className="text-lg md:text-xl font-bold text-gray-300 mb-8">
+        <p className="text-lg md:text-xl font-bold text-white mb-8">
           Enter your phone number to start or manage your reminders.
         </p>
 
@@ -98,47 +98,49 @@ export default function SignInPage() {
             placeholder="+1 (555) 123-4567"
             value={phoneNumber}
             onChange={e => setPhoneNumber(e.target.value)}
-            className="rounded px-3 py-2 bg-gray-900 border border-gray-700 text-white"
+            className="rounded px-3 py-2 bg-black border border-white text-white"
           />
 
           {/* Channel Toggle */}
           <div className="flex gap-2">
             <Button
               onClick={() => setChannel("whatsapp")}
-              className={`flex-1 font-bold ${channel === "whatsapp" ? "bg-green-600 hover:bg-green-700" : "bg-gray-800 hover:bg-gray-700"}`}
+              className={`flex-1 font-bold ${channel === "whatsapp" ? "bg-red-600 hover:bg-red-700" : "bg-white hover:bg-red-700"}`}
             >
               WhatsApp
             </Button>
+            {/*
             <Button
               onClick={() => setChannel("sms")}
-              className={`flex-1 font-bold ${channel === "sms" ? "bg-green-600 hover:bg-green-700" : "bg-gray-800 hover:bg-gray-700"}`}
+              className={`flex-1 font-bold ${channel === "sms" ? "bg-red-600 hover:bg-red-700" : "bg-white hover:bg-red-700"}`}
             >
               SMS
             </Button>
+            */}
           </div>
 
           <Button
             disabled={!isValid}
             onClick={handleSignIn}
-            className="mt-2 w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-2"
+            className="mt-2 w-full bg-red-600 hover:bg-red-700 text-white font-bold py-2"
           >
             Start Reminders <ArrowRight className="ml-2" size={16} />
           </Button>
         </div>
 
         {/* Brutal Mode Section */}
-        <div className="bg-gray-900 border-2 border-gray-700 p-6 rounded-lg text-left mb-10">
+        <div className="bg-black border-2 border-red-600 p-6 rounded-lg text-left mb-10">
           <div className="flex items-center mb-3">
             <Skull className="h-6 w-6 text-red-500 mr-2" />
             <h2 className="text-2xl font-black text-red-400 font-impact">BRUTAL MODE</h2>
           </div>
           <p className="text-red-400 font-bold text-sm mb-2">Brutal Mode is coming soon. Join the waitlist to be the first to try it.</p>
           {waitlistCount !== null && (
-            <p className="text-gray-400 font-bold mb-2">{waitlistCount} people are already on the waitlist.</p>
+            <p className="text-white font-bold mb-2">{waitlistCount} people are already on the waitlist.</p>
           )}
 
           {waitlistSubmitted ? (
-            <p className="text-green-400 font-bold mt-4">Thanks for joining the waitlist!</p>
+            <p className="text-red-400 font-bold mt-4">Thanks for joining the waitlist!</p>
           ) : (
             <form onSubmit={handleWaitlistSubmit} className="flex flex-col gap-3 mt-4">
               <Input
@@ -147,14 +149,14 @@ export default function SignInPage() {
                 placeholder="Email address"
                 value={waitlistEmail}
                 onChange={e => setWaitlistEmail(e.target.value)}
-                className="bg-gray-800 border-gray-700 text-white"
+                className="bg-black border-white text-white"
               />
               <Input
                 type="tel"
                 placeholder="Phone number (optional)"
                 value={waitlistPhone}
                 onChange={e => setWaitlistPhone(e.target.value)}
-                className="bg-gray-800 border-gray-700 text-white"
+                className="bg-black border-white text-white"
               />
               <Button
                 type="submit"
@@ -167,7 +169,7 @@ export default function SignInPage() {
         </div>
 
         {/* Footer Note */}
-        <p className="text-xs text-gray-600 mt-4 font-bold">
+        <p className="text-xs text-white mt-4 font-bold">
           <Smartphone size={12} className="inline-block mr-1" />
           Standard messaging rates may apply.
         </p>


### PR DESCRIPTION
## Summary
- comment out SMS option in sign in page
- switch primary colors to red and white
- update color variables in global stylesheet
- modify dashboard and done pages to remove non-red colors

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688564ccf3c8832eb946b2dcfdd06215